### PR TITLE
Add a message about resetting imports in unit tests

### DIFF
--- a/docs/App.tests.md
+++ b/docs/App.tests.md
@@ -125,6 +125,13 @@ A couple of hints:
 * Use jest.mock to mock `posts.actions`
 * If you are having trouble, you can take a look at the final tests [here](https://github.com/wix-playground/wix-mobile-crash-course/blob/master/src/posts/screens/AddPost.presenter.test.js)
 
+:exclamation: If you're having trouble testing TopBar buttons it's possible that Jest is caching React Native Navigation module, so you should reset your module imports after each test:
+```
+afterEach(() => {
+  jest.resetModules();
+});
+```
+
 ## Quick Recap
 
 Up until now:


### PR DESCRIPTION
On step 4 of Unit testing it seems that `require('react-native-navigation)` caches the module within jest (it’s not reimported in the `beforeEach`). This causes an issue when testing topbar buttons in `AddPost.presenter.js`. This problem doesn't seem to occur when running the tests on this repo but I encountered this issue during onboarding (perhaps an issue due to different versions of Jest used?). I thought it would be useful to include this in the docs.