### PR TITLE
Remove unused filter function in the docs

### DIFF
--- a/docs/App.Remx.md
+++ b/docs/App.Remx.md
@@ -469,7 +469,7 @@ Clicking on the `Delete` button on the `ViewPost` screen must tell our app to de
 
 ```js
 deletePost(id) {
-    state.posts = filter(state.posts, post => post.id !== id);
+    state.posts = state.posts.filter(post => post.id !== id);
 }
 ```
 


### PR DESCRIPTION
Step 12 of Remx docs uses `filter()` to filter out the result, however this method is not defined anywhere.