### PR TITLE
Add a note about installing later version of RNN

### DIFF
--- a/docs/App.Navigation.md
+++ b/docs/App.Navigation.md
@@ -47,6 +47,8 @@ As `react-native-navigation` is a native navigation library, so integrating it i
 
 Make sure your app is still running in both simulators and that you are not getting any red screens.
 
+:exclamation: If you're running React Native 0.60+ make sure you install React Native Navigation v3.0.0 or later.
+
 # Adding the Screens
 ### 3. Create and Register Screens
 
@@ -294,7 +296,7 @@ class AddPost extends Component {
         }],
         leftButtons: [{
           id: 'cancelBtn',
-          icon: require('../../icons/x.icon.png')
+          icon: require('../../icons/x.png')
         }]
       }
     };


### PR DESCRIPTION
This note could've saved me a lot of time. It seems that running `npm i react-native-navigation` installs an older version of React-native-navigation (2.7.1) by default, which does *not  support* AndroidX! The user needs to manually download and save RNN version 3.0.0+ if they want to use RN 0.60+ with AndroidX. Also the "x" icon filename seems to be incorrect.