### PR TITLE
add `npx` to all `react-native` commands

### DIFF
--- a/docs/App.Navigation.md
+++ b/docs/App.Navigation.md
@@ -30,13 +30,13 @@ Here's the outline of what we are going to build in this section:
 You can follow the react-native [getting started guide](https://facebook.github.io/react-native/docs/getting-started)(Choose "React Native CLI Quickstart" and not "Expo Quickstart") to make sure you have all dependencies installed. If this is not the first time you are creating a react-native project just open the terminal and run:
 
 ```sh
-react-native init wixMobileCrashCourse
+npx react-native init wixMobileCrashCourse
 cd wixMobileCrashCourse
 ```
 To run the project you will need to do:
 ```sh
-react-native run-ios
-react-native run-android
+npx react-native run-ios
+npx react-native run-android
 ```
 You should then see your new app running within your simulators:
 


### PR DESCRIPTION
It's preferable to use `npx` with node "binaries" see the official RN docs https://reactnative.dev/docs/environment-setup

> React Native Command Line Interface
React Native has a built-in command line interface. Rather than install and manage a specific version of the CLI globally, we recommend you access the current version at runtime using npx, which ships with Node.js. With npx react-native <command>, the current stable version of the CLI will be downloaded and executed at the time the command is run.